### PR TITLE
Update plot.R

### DIFF
--- a/spring-r/src/main/resources/plot.R
+++ b/spring-r/src/main/resources/plot.R
@@ -1,3 +1,6 @@
+# Check if ggplot2 package is installed. If not, then install it
+if (!require(ggplot2)) install.packages('ggplot2')
+
 library(ggplot2)
 data <<- numeric(100)
 


### PR DESCRIPTION
Add check for ggplot2 package and if not installed, then install during execution of the program. 

This saves the additional `Rscript -e "install.packages(\"ggplot2\")" ` step.